### PR TITLE
Automatically Use Browser Build in React Projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     },
     "exports": {
         ".": {
+            "browser": "./browser/index.js",
             "import": "./build/index.js",
             "require": "./build/index.js",
             "types": "./build/index.d.ts"
@@ -20,6 +21,8 @@
         }
     },
     "browser": {
+        "./build/index.js": "./browser/index.js",
+        "./build/index.d.ts": "./browser/index.d.ts",
         "Buffer": "buffer",
         "crypto": "./src/crypto/crypto-browser.js",
         "stream": "stream-browserify"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,6 +2,7 @@ import webpack from 'webpack';
 
 export default {
     mode: 'production',
+    target: 'web',
     entry: './src/index.ts',
     watch: false,
     output: {


### PR DESCRIPTION
## Description

This pull request updates the `package.json` to ensure that the browser build of `opnet` is used by default in React and browser environments without needing to specify `/browser`.

### Changes Made

- Modified the `browser` field to map the main entry point to the browser build.
- Adjusted the `exports` field to include a `browser` condition.

This simplifies imports in React applications:

```javascript
import { getContract } from 'opnet';
```

No additional configuration is needed, and bundlers will automatically use the correct browser version.