### PR TITLE
Fix import paths in UTXOsManager and AbstractRpcProvider

### DIFF
--- a/src/providers/AbstractRpcProvider.ts
+++ b/src/providers/AbstractRpcProvider.ts
@@ -19,7 +19,7 @@ import { ITransaction } from '../transactions/interfaces/ITransaction.js';
 import { TransactionReceipt } from '../transactions/metadata/TransactionReceipt.js';
 import { TransactionBase } from '../transactions/Transaction.js';
 import { TransactionParser } from '../transactions/TransactionParser.js';
-import { UTXOsManager } from '../utxos/UTXOsManager';
+import { UTXOsManager } from '../utxos/UTXOsManager.js';
 import { GenerateTarget } from './interfaces/Generate.js';
 import { JsonRpcPayload } from './interfaces/JSONRpc.js';
 import { JSONRpcMethods } from './interfaces/JSONRpcMethods.js';

--- a/src/utxos/UTXOsManager.ts
+++ b/src/utxos/UTXOsManager.ts
@@ -1,10 +1,14 @@
-import { IUTXO } from '../bitcoin/interfaces/IUTXO';
-import { UTXO, UTXOs } from '../bitcoin/UTXOs';
-import { AbstractRpcProvider } from '../providers/AbstractRpcProvider';
-import { JsonRpcPayload } from '../providers/interfaces/JSONRpc';
-import { JSONRpcMethods } from '../providers/interfaces/JSONRpcMethods';
-import { JsonRpcResult } from '../providers/interfaces/JSONRpcResult';
-import { IUTXOsData, RequestUTXOsParams, RequestUTXOsParamsWithAmount } from './interfaces/IUTXOsManager.js';
+import { IUTXO } from '../bitcoin/interfaces/IUTXO.js';
+import { UTXO, UTXOs } from '../bitcoin/UTXOs.js';
+import { AbstractRpcProvider } from '../providers/AbstractRpcProvider.js';
+import { JsonRpcPayload } from '../providers/interfaces/JSONRpc.js';
+import { JSONRpcMethods } from '../providers/interfaces/JSONRpcMethods.js';
+import { JsonRpcResult } from '../providers/interfaces/JSONRpcResult.js';
+import {
+    IUTXOsData,
+    RequestUTXOsParams,
+    RequestUTXOsParamsWithAmount,
+} from './interfaces/IUTXOsManager.js';
 
 /**
  * Unspent Transaction Output Manager
@@ -159,7 +163,7 @@ export class UTXOsManager {
             pending: [],
             spentTransactions: [],
         };
-        
+
         return {
             confirmed: result.confirmed.map((utxo: IUTXO) => {
                 return new UTXO(utxo);

--- a/src/utxos/interfaces/IUTXOsManager.ts
+++ b/src/utxos/interfaces/IUTXOsManager.ts
@@ -1,4 +1,4 @@
-import { UTXOs } from '../../bitcoin/UTXOs';
+import { UTXOs } from '../../bitcoin/UTXOs.js';
 
 /**
  * Unspent Transaction Output Manager


### PR DESCRIPTION
Fixed import paths in `UTXOsManager` and `AbstractRpcProvider` to resolve module import errors. Updated paths to include `.js` extension.

Example change:
- From: `import { UTXO, UTXOs } from '../bitcoin/UTXOs';`
- To: `import { UTXO, UTXOs } from '../bitcoin/UTXOs.js';`

This ensures compatibility with ES module imports and prevents issues with missing file extensions during runtime.