### PR TITLE
Fix: Correct ABIs and interfaces for contract interactions to follow OP-20 standards and add getPublicKeyInfo() method to JSONRpcProvider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -405,3 +405,4 @@ build
 browser
 docs
 cjs
+.yarn

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
         }
     },
     "browser": {
-        "./build/index.js": "./browser/index.js",
         "./build/index.d.ts": "./browser/index.d.ts",
+        "./build/index.js": "./browser/index.js",
         "Buffer": "buffer",
         "crypto": "./src/crypto/crypto-browser.js",
         "stream": "stream-browserify"

--- a/src/abi/shared/interfaces/IMotoContract.ts
+++ b/src/abi/shared/interfaces/IMotoContract.ts
@@ -13,5 +13,5 @@ export interface IMotoContract extends IOP_20Contract {
      * @description This method call an airdrop to the given list of addresses.
      * @returns {Promise<BaseContractProperty>}
      */
-    airdrop(list: Map<Address, bigint>): Promise<BaseContractProperty>;
+    airdrop(map_of_recipients_and_amounts: Map<Address, bigint>): Promise<BaseContractProperty>;
 }

--- a/src/abi/shared/interfaces/IOP_20Contract.ts
+++ b/src/abi/shared/interfaces/IOP_20Contract.ts
@@ -38,6 +38,8 @@ export interface IOP_20Contract extends IOP_NETContract {
 
     totalSupply(): Promise<BaseContractProperty>;
 
+    maxSupply(): Promise<BaseContractProperty>;
+
     decimals(): Promise<BaseContractProperty>;
 
     transfer(recipient: BitcoinAddressLike, amount: bigint): Promise<BaseContractProperty>;

--- a/src/abi/shared/interfaces/IOP_20Contract.ts
+++ b/src/abi/shared/interfaces/IOP_20Contract.ts
@@ -30,7 +30,7 @@ import { IOP_NETContract } from './IOP_NETContract.js';
  * console.log('Balance:', balanceExample.decoded);
  */
 export interface IOP_20Contract extends IOP_NETContract {
-    balanceOf(address: BitcoinAddressLike): Promise<BaseContractProperty>;
+    balanceOf(account: BitcoinAddressLike): Promise<BaseContractProperty>;
 
     name(): Promise<BaseContractProperty>;
 
@@ -40,22 +40,20 @@ export interface IOP_20Contract extends IOP_NETContract {
 
     decimals(): Promise<BaseContractProperty>;
 
-    transfer(to: BitcoinAddressLike, value: bigint): Promise<BaseContractProperty>;
+    transfer(recipient: BitcoinAddressLike, amount: bigint): Promise<BaseContractProperty>;
 
     transferFrom(
-        from: BitcoinAddressLike,
-        to: BitcoinAddressLike,
-        value: bigint,
+        sender: BitcoinAddressLike,
+        recipient: BitcoinAddressLike,
+        amount: bigint,
     ): Promise<BaseContractProperty>;
 
-    approve(spender: BitcoinAddressLike, value: bigint): Promise<BaseContractProperty>;
+    approve(spender: BitcoinAddressLike, amount: bigint): Promise<BaseContractProperty>;
 
     allowance(
         owner: BitcoinAddressLike,
         spender: BitcoinAddressLike,
     ): Promise<BaseContractProperty>;
 
-    mint(to: BitcoinAddressLike, value: bigint): Promise<BaseContractProperty>;
-
-    burn(to: BitcoinAddressLike, value: bigint): Promise<BaseContractProperty>;
+    burn(value: bigint): Promise<BaseContractProperty>;
 }

--- a/src/abi/shared/json/MOTO_TOKEN_ABI.ts
+++ b/src/abi/shared/json/MOTO_TOKEN_ABI.ts
@@ -11,7 +11,7 @@ export const MOTO_TOKEN_ABI: BitcoinInterfaceAbi = [
         name: 'airdrop',
         inputs: [
             {
-                name: 'amount',
+                name: 'map_of_recipients_and_amounts',
                 type: ABIDataTypes.ADDRESS_UINT256_TUPLE,
             },
         ],

--- a/src/abi/shared/json/OP_20_ABI.ts
+++ b/src/abi/shared/json/OP_20_ABI.ts
@@ -235,10 +235,10 @@ export const OP_20_ABI: BitcoinInterfaceAbi = [
         type: BitcoinAbiTypes.Function,
     },
     {
-        name: 'maximumSupply',
+        name: 'maxSupply',
         outputs: [
             {
-                name: 'maximumSupply',
+                name: 'maxSupply',
                 type: ABIDataTypes.UINT256,
             },
         ],

--- a/src/abi/shared/json/OP_20_ABI.ts
+++ b/src/abi/shared/json/OP_20_ABI.ts
@@ -101,7 +101,7 @@ export const OP_20_ABI: BitcoinInterfaceAbi = [
                 type: ABIDataTypes.ADDRESS,
             },
             {
-                name: 'value',
+                name: 'amount',
                 type: ABIDataTypes.UINT256,
             },
         ],
@@ -117,7 +117,7 @@ export const OP_20_ABI: BitcoinInterfaceAbi = [
         name: 'balanceOf',
         inputs: [
             {
-                name: 'owner',
+                name: 'account',
                 type: ABIDataTypes.ADDRESS,
             },
         ],
@@ -132,30 +132,6 @@ export const OP_20_ABI: BitcoinInterfaceAbi = [
     {
         name: 'burn',
         inputs: [
-            {
-                name: 'to',
-                type: ABIDataTypes.ADDRESS,
-            },
-            {
-                name: 'value',
-                type: ABIDataTypes.UINT256,
-            },
-        ],
-        outputs: [
-            {
-                name: 'success',
-                type: ABIDataTypes.BOOL,
-            },
-        ],
-        type: BitcoinAbiTypes.Function,
-    },
-    {
-        name: 'mint',
-        inputs: [
-            {
-                name: 'to',
-                type: ABIDataTypes.ADDRESS,
-            },
             {
                 name: 'value',
                 type: ABIDataTypes.UINT256,
@@ -173,11 +149,11 @@ export const OP_20_ABI: BitcoinInterfaceAbi = [
         name: 'transfer',
         inputs: [
             {
-                name: 'to',
+                name: 'recipient',
                 type: ABIDataTypes.ADDRESS,
             },
             {
-                name: 'value',
+                name: 'amount',
                 type: ABIDataTypes.UINT256,
             },
         ],
@@ -193,15 +169,15 @@ export const OP_20_ABI: BitcoinInterfaceAbi = [
         name: 'transferFrom',
         inputs: [
             {
-                name: 'from',
+                name: 'sender',
                 type: ABIDataTypes.ADDRESS,
             },
             {
-                name: 'to',
+                name: 'recipient',
                 type: ABIDataTypes.ADDRESS,
             },
             {
-                name: 'value',
+                name: 'amount',
                 type: ABIDataTypes.UINT256,
             },
         ],
@@ -218,7 +194,6 @@ export const OP_20_ABI: BitcoinInterfaceAbi = [
     {
         name: 'decimals',
         constant: true,
-        inputs: [],
         outputs: [
             {
                 name: 'decimals',
@@ -230,7 +205,6 @@ export const OP_20_ABI: BitcoinInterfaceAbi = [
     {
         name: 'name',
         constant: true,
-        inputs: [],
         outputs: [
             {
                 name: 'name',
@@ -242,7 +216,6 @@ export const OP_20_ABI: BitcoinInterfaceAbi = [
     {
         name: 'symbol',
         constant: true,
-        inputs: [],
         outputs: [
             {
                 name: 'symbol',
@@ -253,7 +226,6 @@ export const OP_20_ABI: BitcoinInterfaceAbi = [
     },
     {
         name: 'totalSupply',
-        inputs: [],
         outputs: [
             {
                 name: 'totalSupply',
@@ -264,7 +236,6 @@ export const OP_20_ABI: BitcoinInterfaceAbi = [
     },
     {
         name: 'maximumSupply',
-        inputs: [],
         outputs: [
             {
                 name: 'maximumSupply',

--- a/src/providers/JSONRpcProvider.ts
+++ b/src/providers/JSONRpcProvider.ts
@@ -20,6 +20,37 @@ export class JSONRpcProvider extends AbstractRpcProvider {
     }
 
     /**
+     * @description Fetches the public key info for a given address.
+     * @param {string} address - The public key or address to fetch the info for
+     * @returns {Promise<IPublicKeyInfo | null>} - The public key info for the address
+     * @throws {Error} - If the fetch fails
+     * @example
+     * ```typescript
+     * const provider = new JSONRpcProvider('https://regtest.opnet.org');
+     * const publicKeyInfo = await provider.getPublicKeyInfo('bcrt1pa0y4fd0sxma50kv9vgqtgll7fd9g3jrsveu4syrnu5s50eurw06sjk54s2');
+     * console.log(publicKeyInfo);
+     * ```
+     */
+    public async getPublicKeyInfo(address: string): Promise<IPublicKeyInfo | null> {
+        const res = await fetch(
+            `${this.url.replace('/api/v1/json-rpc', '')}/api/v1/address/public-key-info`,
+            {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({ address }),
+            },
+        );
+        if (!res.ok) throw new Error(`Failed to fetch: ${res.statusText}`);
+
+        const data = (await res.json()) as IPublicKeyInfoData | null;
+        if (!data) throw new Error('No data fetched');
+
+        return data[address];
+    }
+
+    /**
      * @description Sends a JSON RPC payload to the provider.
      * @param {JsonRpcPayload | JsonRpcPayload[]} payload - The payload to send
      * @returns {Promise<JsonRpcCallResult>} - The result of the call

--- a/src/providers/interfaces/PublicKeyInfo.d.ts
+++ b/src/providers/interfaces/PublicKeyInfo.d.ts
@@ -1,0 +1,21 @@
+interface IPublicKeyInfoData {
+    [key: string]: {
+        lowByte?: number;
+        originalPubKey?: string;
+        tweakedPubkey?: string;
+        p2pkh?: string;
+        p2shp2wpkh?: string;
+        p2tr?: string;
+        p2wpkh?: string;
+    };
+}
+
+interface IPublicKeyInfo {
+    lowByte?: number;
+    originalPubKey?: string;
+    tweakedPubkey?: string;
+    p2pkh?: string;
+    p2shp2wpkh?: string;
+    p2tr?: string;
+    p2wpkh?: string;
+}


### PR DESCRIPTION
### Summary
This pull request fixes the ABIs and interfaces in the OP_NET package to properly align with the OP-20 token standard. The previous configuration had inconsistencies in certain contract interactions, such as the `burn()` function.

### Changes:
- Updated the `burn()` function to follow the OP-20 standard. Previously, it required `burn(to, value)`, and now it correctly uses `burn(value)`.
- Ensured all ABIs and interfaces reflect these changes, making contract interactions more consistent and compatible with the BTC runtime, which already followed the `value-only` pattern.
- Added the `getPublicKeyInfo()` method to `JSONRpcProvider` to retrieve public key information for a given address.

### Reason:
- The previous ABI implementation did not fully conform to the OP-20 standard, which led to unnecessary parameters in functions like `burn()`. This fix removes the extra `to` parameter and aligns the interactions with the expected OP-20 behavior.
- This update ensures smooth interaction with contracts and avoids confusion for developers working with the OP_NET metaprotocol.
- The new `getPublicKeyInfo()` method is added in anticipation of the shift to using public keys for all interactions in OP_NET, making it easier for developers to retrieve and manage public key information.
