### PR TITLE
Update Staking ABI with new function

### DIFF
--- a/src/abi/shared/interfaces/motoswap/IMotoswapStakingContract.ts
+++ b/src/abi/shared/interfaces/motoswap/IMotoswapStakingContract.ts
@@ -1,4 +1,4 @@
-import { ABIDataTypes, Address } from '@btc-vision/transaction';
+import { Address } from '@btc-vision/transaction';
 import { CallResult } from '../../../../opnet.js';
 import { IOwnableReentrancyGuardContract } from './IOwnableReentrancyGuardContract.js';
 
@@ -11,6 +11,10 @@ export type BalanceOf = CallResult<{
 }>;
 
 export type TotalSupply = CallResult<{
+    totalSupply: bigint;
+}>;
+
+export type MotoAddress = CallResult<{
     totalSupply: bigint;
 }>;
 
@@ -96,6 +100,12 @@ export interface IMotoswapStakingContract extends IOwnableReentrancyGuardContrac
     totalSupply(): Promise<TotalSupply>;
 
     /**
+     * @description Returns the address of the MOTO token accepted as a deposit by the staking contract
+     * @returns {MotoAddress}
+     */
+    motoAddress(): Promise<MotoAddress>;
+
+    /**
      * @description Returns the last block the user interacted with the protocol by staking, unstaking or claiming rewards
      * @param address {Address} the address of the staker
      * @returns {TotalSupply}
@@ -168,6 +178,7 @@ export interface IMotoswapStakingContract extends IOwnableReentrancyGuardContrac
     /**
      * @description Changes the address of the Moto token the protocol allows the users to stake
      * Also affects what token is paid out when unstaking.
+     * NOTE: Can only be called if the Moto token address is not set yet (i.e. == Address.dead())
      * @param token {Address} the address of the Moto token
      * @returns {AdminChangeMotoAddress}
      */

--- a/src/abi/shared/json/motoswap/MOTOSWAP_STAKING_ABI.ts
+++ b/src/abi/shared/json/motoswap/MOTOSWAP_STAKING_ABI.ts
@@ -37,6 +37,13 @@ export const MOTOSWAP_STAKING_ABI: BitcoinInterfaceAbi = [
         outputs: [{ name: 'balance', type: ABIDataTypes.UINT256 }],
     },
     {
+        name: 'motoAddress',
+        type: BitcoinAbiTypes.Function,
+        constant: true,
+        inputs: [],
+        outputs: [{ name: 'motoAddress', type: ABIDataTypes.ADDRESS }],
+    },
+    {
         name: 'totalSupply',
         type: BitcoinAbiTypes.Function,
         constant: true,


### PR DESCRIPTION
Added a function to get the current Moto address from the staking contract in the latest audit fixes branch. This commit adds it into the ABIs as well.