### PR TITLE
Update OP20 interfaces and ABIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ lines of code:
 ```typescript
 import {
     getContract,
-    IOP_20Contract,
+    IOP20Contract,
     JSONRpcProvider,
     OP_20_ABI,
     TransactionParameters,
@@ -73,7 +73,7 @@ const provider: JSONRpcProvider = new JSONRpcProvider('https://regtest.opnet.org
 const wallet: Wallet = Configs.WALLET;
 const yourAddress: Address = new Address(wallet.keypair.publicKey);
 
-const example: IOP_20Contract = getContract<IOP_20Contract>(
+const example: IOP20Contract = getContract<IOP20Contract>(
     'bcrt1plz0svv3wl05qrrv0dx8hvh5mgqc7jf3mhqgtw8jnj3l3d3cs6lzsfc3mxh',
     OP_20_ABI,
     provider,

--- a/src/abi/shared/interfaces/generic/IStackingContract.ts
+++ b/src/abi/shared/interfaces/generic/IStackingContract.ts
@@ -8,15 +8,15 @@ import { CallResult } from '../../../../contracts/CallResult.js';
  * @cathegory Contracts
  */
 export interface IStackingContract {
-    stake(amount: bigint): Promise<CallResult<{ success: boolean }>>;
+    stake(amount: bigint): Promise<CallResult<{}>>;
 
-    unstake(): Promise<CallResult<{ success: boolean }>>;
+    unstake(): Promise<CallResult<{}>>;
 
     stakedAmount(address: Address): Promise<CallResult<{ amount: bigint }>>;
 
     stakedReward(address: Address): Promise<CallResult<{ amount: bigint }>>;
 
-    claim(): Promise<CallResult<{ success: boolean }>>;
+    claim(): Promise<CallResult<{}>>;
 
     rewardPool(): Promise<CallResult<{ reward: bigint }>>;
 

--- a/src/abi/shared/interfaces/motoswap/IMoto.ts
+++ b/src/abi/shared/interfaces/motoswap/IMoto.ts
@@ -1,22 +1,18 @@
 import { Address } from '@btc-vision/transaction';
 import { Admin, CallResult, ChangeAdmin } from '../../../../opnet.js';
-import { IOP_20Contract } from '../opnet/IOP_20Contract.js';
+import { IOP20Contract } from '../opnet/IOP20Contract.js';
 
-export type AdminMint = CallResult<{
-    success: boolean;
-}>;
+export type AdminMint = CallResult<{}>;
 
-export type AdminBurn = CallResult<{
-    success: boolean;
-}>;
+export type AdminBurn = CallResult<{}>;
 
 /**
- * @description This interface represents the IMoto contract. It extends the IOP_20Contract and adds the ability to have an admin address that can mint and burn tokens.
+ * @description This interface represents the IMoto contract. It extends the IOP20Contract and adds the ability to have an admin address that can mint and burn tokens.
  * @interface IMoto
- * @extends {IOP_20Contract}
+ * @extends {IOP20Contract}
  * @cathegory Contracts
  */
-export interface IMoto extends IOP_20Contract {
+export interface IMoto extends IOP20Contract {
     /**
      * @description Gets the current admin address.
      * @returns {Admin}

--- a/src/abi/shared/interfaces/motoswap/IMotoChef.ts
+++ b/src/abi/shared/interfaces/motoswap/IMotoChef.ts
@@ -27,21 +27,13 @@ export type Owner = CallResult<
 /**
  * @description Represents the result of the renounceOwnership function call.
  */
-export type RenounceOwnership = CallResult<
-    {
-        success: boolean;
-    },
-    OPNetEvent<OwnershipTransferredEvent>[]
+export type RenounceOwnership = CallResult<{}, OPNetEvent<OwnershipTransferredEvent>[]>
 >;
 
 /**
  * @description Represents the result of the transferOwnership function call.
  */
-export type TransferOwnership = CallResult<
-    {
-        success: boolean;
-    },
-    OPNetEvent<OwnershipTransferredEvent>[]
+export type TransferOwnership = CallResult<{}, OPNetEvent<OwnershipTransferredEvent>[]>
 >;
 
 // ------------------------------------------------------------------
@@ -56,62 +48,57 @@ interface IOwnable extends IOP_NETContract {
 // ------------------------------------------------------------------
 // Event Definitions
 // ------------------------------------------------------------------
-export type LogPoolAdditionEvent = {
+export type PoolAddedEvent = {
     readonly poolId: number;
     readonly allocPoint: bigint;
     readonly lpToken: Address;
 };
-export type LogInitEvent = {};
-export type LogUpdatePoolEvent = {
+export type InitializedEvent = {};
+export type PoolUpdatedEvent = {
     readonly poolId: number;
     readonly lastRewardBlock: bigint;
     readonly lpSupply: bigint;
     readonly accMotoPerShare: bigint;
 };
-export type StakedBTCEvent = {
+export type BTCStakedEvent = {
     readonly user: Address;
     readonly netAmount: bigint;
     readonly stakeTxId: bigint;
     readonly stakeIndex: bigint;
 };
-export type UserOverwriteBTCStakeEvent = {
+export type BTCStakeRemovedEvent = {
     readonly user: Address;
     readonly storedTxId: bigint;
     readonly storedIndex: bigint;
 };
-export type UnstakedBTCEvent = {
+export type BTCUnstakedEvent = {
     readonly user: Address;
     readonly pendingMoto: bigint;
     readonly storedTxId: bigint;
     readonly storedIndex: bigint;
 };
-export type RemovedBTCStakeEvent = {
-    readonly user: Address;
-    readonly storedTxId: bigint;
-    readonly storedIndex: bigint;
-};
-export type LogSetPoolEvent = {
+export type PoolSetEvent = {
     readonly poolId: number;
     readonly allocPoint: bigint;
 };
-export type DepositEvent = {
+export type DepositedEvent = {
     readonly user: Address;
     readonly poolId: number;
     readonly amount: bigint;
     readonly to: Address;
 };
-export type WithdrawEvent = {
+export type WithdrawnEvent = {
     readonly user: Address;
     readonly poolId: number;
     readonly amount: bigint;
     readonly to: Address;
 };
-export type HarvestEvent = {
+export type HarvestedEvent = {
     readonly user: Address;
     readonly poolId: number;
     readonly amount: bigint;
 };
-export type EmergencyWithdrawEvent = {
+export type EmergencyWithdrawnEvent = {
     readonly user: Address;
     readonly poolId: number;
     readonly amount: bigint;
@@ -125,12 +112,7 @@ export type EmergencyWithdrawEvent = {
 /**
  * @description Represents the result of the initialize function call.
  */
-export type Initialize = CallResult<
-    {
-        success: boolean;
-    },
-    OPNetEvent<LogPoolAdditionEvent | LogInitEvent>[]
->;
+export type Initialize = CallResult<{}, OPNetEvent<PoolAddedEvent | InitializedEvent>[]>;
 
 /**
  * @description Represents the result of the totalAllocPoint function call.
@@ -298,51 +280,31 @@ export type TotalBTCStaked = CallResult<
 /**
  * @description Represents the result of the stakeBTC function call.
  */
-export type StakeBTC = CallResult<
-    {
-        success: boolean;
-    },
-    OPNetEvent<LogUpdatePoolEvent | StakedBTCEvent | UserOverwriteBTCStakeEvent>[]
+export type StakeBTC = CallResult<{}, OPNetEvent<PoolUpdatedEvent | BTCStakedEvent | BTCStakeRemovedEvent>[]>
 >;
 
 /**
  * @description Represents the result of the unstakeBTC function call.
  */
-export type UnstakeBTC = CallResult<
-    {
-        success: boolean;
-    },
-    OPNetEvent<LogUpdatePoolEvent | UnstakedBTCEvent>[]
+export type UnstakeBTC = CallResult<{}, OPNetEvent<PoolUpdatedEvent | BTCUnstakedEvent>[]>
 >;
 
 /**
  * @description Represents the result of the removeBTCStake function call.
  */
-export type RemoveBTCStake = CallResult<
-    {
-        success: boolean;
-    },
-    OPNetEvent<LogUpdatePoolEvent | RemovedBTCStakeEvent>[]
+export type RemoveBTCStake = CallResult<{}, OPNetEvent<PoolUpdatedEvent | BTCStakeRemovedEvent>[]>
 >;
 
 /**
  * @description Represents the result of the add function call.
  */
-export type Add = CallResult<
-    {
-        success: boolean;
-    },
-    OPNetEvent<LogPoolAdditionEvent>[]
+export type Add = CallResult<{}, OPNetEvent<PoolAddedEvent>[]>
 >;
 
 /**
  * @description Represents the result of the set function call.
  */
-export type Set = CallResult<
-    {
-        success: boolean;
-    },
-    OPNetEvent<LogSetPoolEvent>[]
+export type Set = CallResult<{}, OPNetEvent<PoolSetEvent>[]>
 >;
 
 /**
@@ -354,107 +316,67 @@ export type UpdatePool = CallResult<
         lastRewardBlock: bigint;
         allocPoint: bigint;
     },
-    OPNetEvent<LogUpdatePoolEvent>[]
+    OPNetEvent<PoolUpdatedEvent>[]
 >;
 
 /**
  * @description Represents the result of the massUpdatePools function call.
  */
-export type MassUpdatePools = CallResult<
-    {
-        success: boolean;
-    },
-    OPNetEvent<LogUpdatePoolEvent>[]
+export type MassUpdatePools = CallResult<{}, OPNetEvent<PoolUpdatedEvent>[]>
 >;
 
 /**
  * @description Represents the result of the deposit function call.
  */
-export type Deposit = CallResult<
-    {
-        success: boolean;
-    },
-    OPNetEvent<LogUpdatePoolEvent | DepositEvent>[]
+export type Deposit = CallResult<{}, OPNetEvent<PoolUpdatedEvent | DepositedEvent>[]>
 >;
 
 /**
  * @description Represents the result of the withdraw function call.
  */
-export type Withdraw = CallResult<
-    {
-        success: boolean;
-    },
-    OPNetEvent<LogUpdatePoolEvent | WithdrawEvent>[]
+export type Withdraw = CallResult<{}, OPNetEvent<PoolUpdatedEvent | WithdrawnEvent>[]>
 >;
 
 /**
  * @description Represents the result of the harvest function call.
  */
-export type Harvest = CallResult<
-    {
-        success: boolean;
-    },
-    OPNetEvent<LogUpdatePoolEvent | HarvestEvent>[]
+export type Harvest = CallResult<{}, OPNetEvent<PoolUpdatedEvent | HarvestedEvent>[]>
 >;
 
 /**
  * @description Represents the result of the withdrawAndHarvest function call.
  */
-export type WithdrawAndHarvest = CallResult<
-    {
-        success: boolean;
-    },
-    OPNetEvent<LogUpdatePoolEvent | WithdrawEvent | HarvestEvent>[]
+export type WithdrawAndHarvest = CallResult<{}, OPNetEvent<PoolUpdatedEvent | WithdrawnEvent | HarvestedEvent>[]>
 >;
 
 /**
  * @description Represents the result of the emergencyWithdraw function call.
  */
-export type EmergencyWithdraw = CallResult<
-    {
-        success: boolean;
-    },
-    OPNetEvent<EmergencyWithdrawEvent>[]
+export type EmergencyWithdraw = CallResult<{}, OPNetEvent<EmergencyWithdrawnEvent>[]>
 >;
 
 /**
  * @description Represents the result of the setMotoPerBlock function call.
  */
-export type SetMotoPerBlock = CallResult<
-    {
-        success: boolean;
-    },
-    OPNetEvent<never>[]
+export type SetMotoPerBlock = CallResult<{}, OPNetEvent<never>[]>
 >;
 
 /**
  * @description Represents the result of the setBonusEndBlock function call.
  */
-export type SetBonusEndBlock = CallResult<
-    {
-        success: boolean;
-    },
-    OPNetEvent<never>[]
+export type SetBonusEndBlock = CallResult<{}, OPNetEvent<never>[]>
 >;
 
 /**
  * @description Represents the result of the setBonusMultiplier function call.
  */
-export type SetBonusMultiplier = CallResult<
-    {
-        success: boolean;
-    },
-    OPNetEvent<never>[]
+export type SetBonusMultiplier = CallResult<{}, OPNetEvent<never>[]>
 >;
 
 /**
  * @description Represents the result of the setDev function call.
  */
-export type SetDev = CallResult<
-    {
-        success: boolean;
-    },
-    OPNetEvent<never>[]
+export type SetDev = CallResult<{}, OPNetEvent<never>[]>
 >;
 
 // ------------------------------------------------------------------

--- a/src/abi/shared/interfaces/motoswap/IMotoswapFactoryContract.ts
+++ b/src/abi/shared/interfaces/motoswap/IMotoswapFactoryContract.ts
@@ -37,7 +37,7 @@ export interface IMotoswapFactoryContract extends IOP_NETContract {
 
     setStakingContractAddress(
         stakingContractAddress: Address,
-    ): Promise<CallResult<{ success: boolean }>>;
+    ): Promise<CallResult<{}>>;
 
     getStakingContractAddress(): Promise<CallResult<{ stakingContractAddress: Address }>>;
 }

--- a/src/abi/shared/interfaces/motoswap/IMotoswapPoolContract.ts
+++ b/src/abi/shared/interfaces/motoswap/IMotoswapPoolContract.ts
@@ -1,7 +1,7 @@
 import { Address } from '@btc-vision/transaction';
 import { CallResult } from '../../../../contracts/CallResult.js';
 import { OPNetEvent } from '../../../../contracts/OPNetEvent.js';
-import { IOP_20Contract } from '../opnet/IOP_20Contract.js';
+import { IOP20Contract } from '../opnet/IOP20Contract.js';
 
 export type Reserves = {
     readonly reserve0: bigint;
@@ -10,19 +10,20 @@ export type Reserves = {
 };
 
 // Events
-export type PoolBurnEvent = {
+export type BurnedEvent = {
+    readonly sender: Address;
+    readonly amount0: bigint;
+    readonly amount1: bigint;
+    readonly to: Address;
+};
+
+export type MintedEvent = {
     readonly sender: Address;
     readonly amount0: bigint;
     readonly amount1: bigint;
 };
 
-export type PoolMintEvent = {
-    readonly sender: Address;
-    readonly amount0: bigint;
-    readonly amount1: bigint;
-};
-
-export type SwapEvent = {
+export type SwappedEvent = {
     readonly sender: Address;
     readonly amount0In: bigint;
     readonly amount1In: bigint;
@@ -34,10 +35,10 @@ export type SwapEvent = {
 /**
  * @description This interface represents a motoswap pool contract.
  * @interface IMotoswapPoolContract
- * @extends {Omit<IOP_20Contract, 'burn' | 'mint'>}
+ * @extends {Omit<IOP20Contract, 'burn' | 'mint'>}
  * @cathegory Contracts
  */
-export interface IMotoswapPoolContract extends Omit<IOP_20Contract, 'burn' | 'mint'> {
+export interface IMotoswapPoolContract extends Omit<IOP20Contract, 'burn' | 'mint'> {
     /**
      * @description This method returns the token0 address.
      * @returns {Promise<CallResult<{ token0: Address }>>}
@@ -69,19 +70,12 @@ export interface IMotoswapPoolContract extends Omit<IOP_20Contract, 'burn' | 'mi
         amount1Out: bigint,
         to: string,
         data: Uint8Array,
-    ): Promise<
-        CallResult<
-            {
-                success: boolean;
-            },
-            [OPNetEvent<SwapEvent>]
-        >
-    >;
+    ): Promise<CallResult<{}, [OPNetEvent<SwappedEvent>]>>;
 
     /**
      * Skim
      */
-    skim(): Promise<CallResult<{ success: boolean }>>;
+    skim(): Promise<CallResult<{}>>;
 
     /**
      * kLast
@@ -95,7 +89,7 @@ export interface IMotoswapPoolContract extends Omit<IOP_20Contract, 'burn' | 'mi
      */
     burn(
         to: Address,
-    ): Promise<CallResult<{ amount0: bigint; amount1: bigint }, [OPNetEvent<PoolBurnEvent>]>>;
+    ): Promise<CallResult<{ amount0: bigint; amount1: bigint }, [OPNetEvent<BurnedEvent>]>>;
 
     /**
      * Get block timestamp last
@@ -106,7 +100,7 @@ export interface IMotoswapPoolContract extends Omit<IOP_20Contract, 'burn' | 'mi
      * @description This method syncs the pool.
      * @returns {Promise<CallResult>}
      */
-    sync(): Promise<CallResult<{ success: boolean }>>;
+    sync(): Promise<CallResult<{}>>;
 
     /**
      * @description This method returns the price0 cumulative last.
@@ -124,7 +118,7 @@ export interface IMotoswapPoolContract extends Omit<IOP_20Contract, 'burn' | 'mi
 
     MINIMUM_LIQUIDITY(): Promise<CallResult<{ MINIMUM_LIQUIDITY: bigint }>>;
 
-    mint(to: Address): Promise<CallResult<{ liquidity: bigint }, [OPNetEvent<PoolMintEvent>]>>;
+    mint(to: Address): Promise<CallResult<{ liquidity: bigint }, [OPNetEvent<MintedEvent>]>>;
 
-    initialize(token0: Address, token1: Address): Promise<CallResult<{ success: boolean }>>;
+    initialize(token0: Address, token1: Address): Promise<CallResult<{}>>;
 }

--- a/src/abi/shared/interfaces/motoswap/IMotoswapRouterContract.ts
+++ b/src/abi/shared/interfaces/motoswap/IMotoswapRouterContract.ts
@@ -90,7 +90,7 @@ export interface IMotoswapRouterContract extends IOP_NETContract {
         path: Address[],
         to: Address,
         deadline: bigint,
-    ): Promise<CallResult<{ success: boolean }>>;
+    ): Promise<CallResult<{}>>;
 
     /**
      * @description Get the factory address.

--- a/src/abi/shared/interfaces/motoswap/IMotoswapStakingContract.ts
+++ b/src/abi/shared/interfaces/motoswap/IMotoswapStakingContract.ts
@@ -1,6 +1,6 @@
 import { Address } from '@btc-vision/transaction';
 import { CallResult } from '../../../../contracts/CallResult.js';
-import { BalanceOf, TotalSupply } from '../opnet/IOP_20Contract.js';
+import { BalanceOf, TotalSupply } from '../opnet/IOP20Contract.js';
 import { IOP_NETContract } from '../opnet/IOP_NETContract.js';
 
 export type Status = CallResult<{ status: bigint }>;
@@ -24,9 +24,7 @@ export type Admin = CallResult<{
     adminAddress: Address;
 }>;
 
-export type ChangeAdmin = CallResult<{
-    success: boolean;
-}>;
+export type ChangeAdmin = CallResult<{}>;
 
 /**
  * @description This interface represents the OwnableReentrancyGuard contract.
@@ -82,37 +80,21 @@ export type EnabledRewardTokens = CallResult<{
     enabledRewardTokens: Address[];
 }>;
 
-export type Stake = CallResult<{
-    success: boolean;
-}>;
+export type Stake = CallResult<{}>;
 
-export type Unstake = CallResult<{
-    success: boolean;
-}>;
+export type Unstake = CallResult<{}>;
 
-export type ClaimRewards = CallResult<{
-    success: boolean;
-}>;
+export type ClaimRewards = CallResult<{}>;
 
-export type AdminAddRewardToken = CallResult<{
-    success: boolean;
-}>;
+export type AdminAddRewardToken = CallResult<{}>;
 
-export type AdminRemoveRewardToken = CallResult<{
-    success: boolean;
-}>;
+export type AdminRemoveRewardToken = CallResult<{}>;
 
-export type AdminChangeMotoAddress = CallResult<{
-    success: boolean;
-}>;
+export type AdminChangeMotoAddress = CallResult<{}>;
 
-export type AdminChangeLockupParameters = CallResult<{
-    success: boolean;
-}>;
+export type AdminChangeLockupParameters = CallResult<{}>;
 
-export type AdminEnableEmergencyWithdrawals = CallResult<{
-    success: boolean;
-}>;
+export type AdminEnableEmergencyWithdrawals = CallResult<{}>;
 
 // EVENTS
 export type RewardTokenAddedEvent = {

--- a/src/abi/shared/interfaces/motoswap/INativeSwapContract.ts
+++ b/src/abi/shared/interfaces/motoswap/INativeSwapContract.ts
@@ -1,7 +1,7 @@
 import { Address } from '@btc-vision/transaction';
 import { CallResult } from '../../../../contracts/CallResult.js';
 import { OPNetEvent } from '../../../../contracts/OPNetEvent.js';
-import { TransferEvent } from '../opnet/IOP_20Contract.js';
+import { TransferredEvent } from '../opnet/IOP20Contract.js';
 import { IOP_NETContract } from '../opnet/IOP_NETContract.js';
 
 export type LiquidityAddedEvent = {
@@ -76,32 +76,32 @@ export type FulfilledProviderEvent = {
 export type ReserveNativeSwap = CallResult<
     { ok: boolean },
     OPNetEvent<
-        LiquidityReservedEvent | ReservationCreatedEvent | TransferEvent | FulfilledProviderEvent
+        LiquidityReservedEvent | ReservationCreatedEvent | TransferredEvent | FulfilledProviderEvent
     >[]
 >;
 
 export type AddLiquidity = CallResult<
     { ok: boolean },
     OPNetEvent<
-        LiquidityAddedEvent | TransferEvent | ActivateProviderEvent | FulfilledProviderEvent
+        LiquidityAddedEvent | TransferredEvent | ActivateProviderEvent | FulfilledProviderEvent
     >[]
 >;
 
 export type RemoveLiquidity = CallResult<
     { ok: boolean },
-    OPNetEvent<LiquidityRemovedEvent | TransferEvent | FulfilledProviderEvent>[]
+    OPNetEvent<LiquidityRemovedEvent | TransferredEvent | FulfilledProviderEvent>[]
 >;
 
 export type ListLiquidity = CallResult<{ ok: boolean }, OPNetEvent<LiquidityListedEvent>[]>;
 
 export type CancelListing = CallResult<
     { ok: boolean },
-    OPNetEvent<ListingCanceledEvent | TransferEvent | FulfilledProviderEvent>[]
+    OPNetEvent<ListingCanceledEvent | TransferredEvent | FulfilledProviderEvent>[]
 >;
 
 export type CreatePool = CallResult<
     { ok: boolean },
-    OPNetEvent<TransferEvent | LiquidityAddedEvent>[]
+    OPNetEvent<TransferredEvent | LiquidityAddedEvent>[]
 >;
 
 export type SetFees = CallResult<{ ok: boolean }, []>;
@@ -110,7 +110,7 @@ export type GetFees = CallResult<{ reservationBaseFee: bigint; priorityQueueBase
 
 export type Swap = CallResult<
     { ok: boolean },
-    OPNetEvent<SwapExecutedEvent | TransferEvent | ActivateProviderEvent | FulfilledProviderEvent>[]
+    OPNetEvent<SwapExecutedEvent | TransferredEvent | ActivateProviderEvent | FulfilledProviderEvent>[]
 >;
 
 export type GetReserve = CallResult<

--- a/src/abi/shared/interfaces/opnet/IOP20Contract.ts
+++ b/src/abi/shared/interfaces/opnet/IOP20Contract.ts
@@ -3,22 +3,23 @@ import { CallResult } from '../../../../contracts/CallResult.js';
 import { OPNetEvent } from '../../../../contracts/OPNetEvent.js';
 import { IOP_NETContract } from './IOP_NETContract.js';
 
-export type MintEvent = {
+export type MintedEvent = {
     to: Address;
     amount: bigint;
 };
 
-export type TransferEvent = {
+export type TransferredEvent = {
     from: Address;
     to: Address;
     amount: bigint;
 };
 
-export type BurnEvent = {
+export type BurnedEvent = {
+    from: Address;
     amount: bigint;
 };
 
-export type ApproveEvent = {
+export type ApprovedEvent = {
     owner: Address;
     spender: Address;
     value: bigint;
@@ -30,38 +31,37 @@ export type SymbolOf = CallResult<{ symbol: string }, []>;
 export type TotalSupply = CallResult<{ totalSupply: bigint }, []>;
 export type MaxSupply = CallResult<{ maximumSupply: bigint }, []>;
 export type Decimals = CallResult<{ decimals: number }, []>;
+export type DomainSeparator = CallResult<{ domainSeparator: Uint8Array }, []>;
+export type NonceOf = CallResult<{ nonce: bigint }, []>;
 
-export type Transfer = CallResult<
-    {
-        success: boolean;
-    },
-    [OPNetEvent<TransferEvent>]
->;
-
-export type TransferFrom = CallResult<{ success: boolean }, [OPNetEvent<TransferEvent>]>;
-export type Approve = CallResult<{ success: boolean }, [OPNetEvent<ApproveEvent>]>;
+export type Transfer = CallResult<{}, [OPNetEvent<TransferredEvent>]>;
+export type TransferFrom = CallResult<{}, [OPNetEvent<TransferredEvent>]>;
+export type IncreaseAllowance = CallResult<{}, [OPNetEvent<ApprovedEvent>]>;
+export type DecreaseAllowance = CallResult<{}, [OPNetEvent<ApprovedEvent>]>;
+export type IncreaseAllowanceBySignature = CallResult<{}, [OPNetEvent<ApprovedEvent>]>;
+export type DecreaseAllowanceBySignature = CallResult<{}, [OPNetEvent<ApprovedEvent>]>;
 export type Allowance = CallResult<{ remaining: bigint }, []>;
-export type Burn = CallResult<{ success: boolean }, [OPNetEvent<BurnEvent>]>;
-export type Mint = CallResult<{ success: boolean }, [OPNetEvent<MintEvent>]>;
-export type Airdrop = CallResult<{ success: boolean }, OPNetEvent<MintEvent>[]>;
-export type AirdropWithAmount = CallResult<{ success: boolean }, OPNetEvent<MintEvent>[]>;
+export type Burn = CallResult<{}, [OPNetEvent<BurnedEvent>]>;
+export type Mint = CallResult<{}, [OPNetEvent<MintedEvent>]>;
+export type Airdrop = CallResult<{}, OPNetEvent<MintedEvent>[]>;
+export type AirdropWithAmount = CallResult<{}, OPNetEvent<MintedEvent>[]>;
 
 /**
- * @description This interface represents the OP_20 base contract.
- * @interface IOP_20Contract
+ * @description This interface represents the OP20 base contract.
+ * @interface IOP20Contract
  * @extends {IOP_NETContract}
  * @cathegory Contracts
  *
  * @example
  * import { Address } from '@btc-vision/transaction';
- * import { IOP_20Contract } from '../abi/shared/interfaces/IOP_20Contract.js';
+ * import { IOP20Contract } from '../abi/shared/interfaces/IOP20Contract.js';
  * import { OP_20_ABI } from '../abi/shared/json/OP_20_ABI.js';
  * import { CallResult } from '../contracts/CallResult.js';
  * import { getContract } from '../contracts/Contract.js';
  * import { JSONRpcProvider } from '../providers/JSONRpcProvider.js';
  *
  * const provider: JSONRpcProvider = new JSONRpcProvider('https://regtest.opnet.org');
- * const contract: IOP_20Contract = getContract<IOP_20Contract>(
+ * const contract: IOP20Contract = getContract<IOP20Contract>(
  *     'bcrt1pyrs3eqwnrmd4ql3nwvx66yzp0wc24xd2t9pf8699ln340pjs7f3sar3tum',
  *     OP_20_ABI,
  *     provider,
@@ -79,7 +79,7 @@ export type AirdropWithAmount = CallResult<{ success: boolean }, OPNetEvent<Mint
  *
  * console.log('Balance:', balanceExample.properties.balance);
  */
-export interface IOP_20Contract extends IOP_NETContract {
+export interface IOP20Contract extends IOP_NETContract {
     balanceOf(account: Address): Promise<BalanceOf>;
 
     name(): Promise<Name>;
@@ -90,15 +90,35 @@ export interface IOP_20Contract extends IOP_NETContract {
 
     maximumSupply(): Promise<MaxSupply>;
 
+    domainSeparator(): Promise<DomainSeparator>;
+
+    nonceOf(owner: Address): Promise<NonceOf>;
+
     decimals(): Promise<Decimals>;
 
-    transfer(recipient: Address, amount: bigint): Promise<Transfer>;
+    safeTransfer(to: Address, amount: bigint, data: Uint8Array): Promise<Transfer>;
 
-    transferFrom(sender: Address, recipient: Address, amount: bigint): Promise<TransferFrom>;
+    safeTransferFrom(from: Address, to: Address, amount: bigint, data: Uint8Array): Promise<TransferFrom>;
 
-    approve(spender: Address, amount: bigint): Promise<Approve>;
+    increaseAllowance(spender: Address, amount: bigint): Promise<IncreaseAllowance>;
 
-    approveFrom(spender: Address, amount: bigint, signature: Uint8Array): Promise<Approve>;
+    decreaseAllowance(spender: Address, amount: bigint): Promise<DecreaseAllowance>;
+
+    increaseAllowanceBySignature(
+        owner: Address,
+        spender: Address,
+        amount: bigint,
+        deadline: bigint,
+        signature: Uint8Array,
+    ): Promise<IncreaseAllowanceBySignature>;
+
+    decreaseAllowanceBySignature(
+        owner: Address,
+        spender: Address,
+        amount: bigint,
+        deadline: bigint,
+        signature: Uint8Array,
+    ): Promise<DecreaseAllowanceBySignature>;
 
     allowance(owner: Address, spender: Address): Promise<Allowance>;
 

--- a/src/abi/shared/json/generic/STAKING_ABI.ts
+++ b/src/abi/shared/json/generic/STAKING_ABI.ts
@@ -44,23 +44,13 @@ export const STAKING_ABI: BitcoinInterfaceAbi = [
                 type: ABIDataTypes.UINT256,
             },
         ],
-        outputs: [
-            {
-                name: 'success',
-                type: ABIDataTypes.BOOL,
-            },
-        ],
+        outputs: [],
         type: BitcoinAbiTypes.Function,
     },
     {
         name: 'unstake',
         inputs: [],
-        outputs: [
-            {
-                name: 'success',
-                type: ABIDataTypes.BOOL,
-            },
-        ],
+        outputs: [],
         type: BitcoinAbiTypes.Function,
     },
     {
@@ -98,12 +88,7 @@ export const STAKING_ABI: BitcoinInterfaceAbi = [
     {
         name: 'claim',
         inputs: [],
-        outputs: [
-            {
-                name: 'success',
-                type: ABIDataTypes.BOOL,
-            },
-        ],
+        outputs: [],
         type: BitcoinAbiTypes.Function,
     },
     {

--- a/src/abi/shared/json/motoswap/MOTOCHEF_ABI.ts
+++ b/src/abi/shared/json/motoswap/MOTOCHEF_ABI.ts
@@ -36,12 +36,7 @@ const OWNABLE_ABI: BitcoinInterfaceAbi = [
         name: 'renounceOwnership',
         type: BitcoinAbiTypes.Function,
         inputs: [],
-        outputs: [
-            {
-                name: 'success',
-                type: ABIDataTypes.BOOL,
-            },
-        ],
+        outputs: [],
     },
     {
         name: 'transferOwnership',
@@ -52,18 +47,13 @@ const OWNABLE_ABI: BitcoinInterfaceAbi = [
                 type: ABIDataTypes.ADDRESS,
             },
         ],
-        outputs: [
-            {
-                name: 'success',
-                type: ABIDataTypes.BOOL,
-            },
-        ],
+        outputs: [],
     },
 ];
 
 const MotoChefEvents: BitcoinInterfaceAbi = [
     {
-        name: 'LogPoolAddition',
+        name: 'PoolAdded',
         values: [
             {
                 name: 'poolId',
@@ -81,12 +71,12 @@ const MotoChefEvents: BitcoinInterfaceAbi = [
         type: BitcoinAbiTypes.Event,
     },
     {
-        name: 'LogInit',
+        name: 'Initialized',
         values: [],
         type: BitcoinAbiTypes.Event,
     },
     {
-        name: 'LogUpdatePool',
+        name: 'PoolUpdated',
         values: [
             {
                 name: 'poolId',
@@ -108,7 +98,7 @@ const MotoChefEvents: BitcoinInterfaceAbi = [
         type: BitcoinAbiTypes.Event,
     },
     {
-        name: 'StakedBTC',
+        name: 'BTCStaked',
         values: [
             {
                 name: 'user',
@@ -130,7 +120,7 @@ const MotoChefEvents: BitcoinInterfaceAbi = [
         type: BitcoinAbiTypes.Event,
     },
     {
-        name: 'UserOverwriteBTCStake',
+        name: 'BTCStakeRemoved',
         values: [
             {
                 name: 'user',
@@ -148,7 +138,7 @@ const MotoChefEvents: BitcoinInterfaceAbi = [
         type: BitcoinAbiTypes.Event,
     },
     {
-        name: 'UnstakedBTC',
+        name: 'BTCUnstaked',
         values: [
             {
                 name: 'user',
@@ -170,7 +160,7 @@ const MotoChefEvents: BitcoinInterfaceAbi = [
         type: BitcoinAbiTypes.Event,
     },
     {
-        name: 'RemovedBTCStake',
+        name: 'BTCStakeRemoved',
         values: [
             {
                 name: 'user',
@@ -188,7 +178,7 @@ const MotoChefEvents: BitcoinInterfaceAbi = [
         type: BitcoinAbiTypes.Event,
     },
     {
-        name: 'LogSetPool',
+        name: 'PoolSet',
         values: [
             {
                 name: 'poolId',
@@ -202,7 +192,7 @@ const MotoChefEvents: BitcoinInterfaceAbi = [
         type: BitcoinAbiTypes.Event,
     },
     {
-        name: 'Deposit',
+        name: 'Deposited',
         values: [
             {
                 name: 'user',
@@ -224,7 +214,7 @@ const MotoChefEvents: BitcoinInterfaceAbi = [
         type: BitcoinAbiTypes.Event,
     },
     {
-        name: 'Withdraw',
+        name: 'Withdrawn',
         values: [
             {
                 name: 'user',
@@ -246,7 +236,7 @@ const MotoChefEvents: BitcoinInterfaceAbi = [
         type: BitcoinAbiTypes.Event,
     },
     {
-        name: 'Harvest',
+        name: 'Harvested',
         values: [
             {
                 name: 'user',
@@ -264,7 +254,7 @@ const MotoChefEvents: BitcoinInterfaceAbi = [
         type: BitcoinAbiTypes.Event,
     },
     {
-        name: 'EmergencyWithdraw',
+        name: 'EmergencyWithdrawn',
         values: [
             {
                 name: 'user',
@@ -329,12 +319,7 @@ export const MOTOCHEF_ABI: BitcoinInterfaceAbi = [
                 type: ABIDataTypes.UINT256,
             },
         ],
-        outputs: [
-            {
-                name: 'success',
-                type: ABIDataTypes.BOOL,
-            },
-        ],
+        outputs: [],
     },
     {
         name: 'totalAllocPoint',
@@ -580,23 +565,13 @@ export const MOTOCHEF_ABI: BitcoinInterfaceAbi = [
                 type: ABIDataTypes.UINT256,
             },
         ],
-        outputs: [
-            {
-                name: 'success',
-                type: ABIDataTypes.BOOL,
-            },
-        ],
+        outputs: [],
     },
     {
         name: 'unstakeBTC',
         type: BitcoinAbiTypes.Function,
         inputs: [],
-        outputs: [
-            {
-                name: 'success',
-                type: ABIDataTypes.BOOL,
-            },
-        ],
+        outputs: [],
     },
     {
         name: 'removeBTCStake',
@@ -607,12 +582,7 @@ export const MOTOCHEF_ABI: BitcoinInterfaceAbi = [
                 type: ABIDataTypes.ADDRESS,
             },
         ],
-        outputs: [
-            {
-                name: 'success',
-                type: ABIDataTypes.BOOL,
-            },
-        ],
+        outputs: [],
     },
     {
         name: 'add',
@@ -627,12 +597,7 @@ export const MOTOCHEF_ABI: BitcoinInterfaceAbi = [
                 type: ABIDataTypes.ADDRESS,
             },
         ],
-        outputs: [
-            {
-                name: 'success',
-                type: ABIDataTypes.BOOL,
-            },
-        ],
+        outputs: [],
     },
     {
         name: 'set',
@@ -647,12 +612,7 @@ export const MOTOCHEF_ABI: BitcoinInterfaceAbi = [
                 type: ABIDataTypes.UINT256,
             },
         ],
-        outputs: [
-            {
-                name: 'success',
-                type: ABIDataTypes.BOOL,
-            },
-        ],
+        outputs: [],
     },
     {
         name: 'updatePool',
@@ -691,12 +651,7 @@ export const MOTOCHEF_ABI: BitcoinInterfaceAbi = [
                 type: ABIDataTypes.ARRAY_OF_UINT32,
             },
         ],
-        outputs: [
-            {
-                name: 'success',
-                type: ABIDataTypes.BOOL,
-            },
-        ],
+        outputs: [],
     },
     {
         name: 'deposit',
@@ -715,12 +670,7 @@ export const MOTOCHEF_ABI: BitcoinInterfaceAbi = [
                 type: ABIDataTypes.ADDRESS,
             },
         ],
-        outputs: [
-            {
-                name: 'success',
-                type: ABIDataTypes.BOOL,
-            },
-        ],
+        outputs: [],
     },
     {
         name: 'withdraw',
@@ -739,12 +689,7 @@ export const MOTOCHEF_ABI: BitcoinInterfaceAbi = [
                 type: ABIDataTypes.ADDRESS,
             },
         ],
-        outputs: [
-            {
-                name: 'success',
-                type: ABIDataTypes.BOOL,
-            },
-        ],
+        outputs: [],
     },
     {
         name: 'harvest',
@@ -759,15 +704,10 @@ export const MOTOCHEF_ABI: BitcoinInterfaceAbi = [
                 type: ABIDataTypes.ADDRESS,
             },
         ],
-        outputs: [
-            {
-                name: 'success',
-                type: ABIDataTypes.BOOL,
-            },
-        ],
+        outputs: [],
     },
     {
-        name: 'withdrawAndHarvest',
+        name: 'withdrawAndHarvested',
         type: BitcoinAbiTypes.Function,
         inputs: [
             {
@@ -783,12 +723,7 @@ export const MOTOCHEF_ABI: BitcoinInterfaceAbi = [
                 type: ABIDataTypes.ADDRESS,
             },
         ],
-        outputs: [
-            {
-                name: 'success',
-                type: ABIDataTypes.BOOL,
-            },
-        ],
+        outputs: [],
     },
     {
         name: 'emergencyWithdraw',
@@ -803,12 +738,7 @@ export const MOTOCHEF_ABI: BitcoinInterfaceAbi = [
                 type: ABIDataTypes.ADDRESS,
             },
         ],
-        outputs: [
-            {
-                name: 'success',
-                type: ABIDataTypes.BOOL,
-            },
-        ],
+        outputs: [],
     },
     {
         name: 'setMotoPerBlock',
@@ -819,12 +749,7 @@ export const MOTOCHEF_ABI: BitcoinInterfaceAbi = [
                 type: ABIDataTypes.UINT256,
             },
         ],
-        outputs: [
-            {
-                name: 'success',
-                type: ABIDataTypes.BOOL,
-            },
-        ],
+        outputs: [],
     },
     {
         name: 'setBonusEndBlock',
@@ -835,12 +760,7 @@ export const MOTOCHEF_ABI: BitcoinInterfaceAbi = [
                 type: ABIDataTypes.UINT256,
             },
         ],
-        outputs: [
-            {
-                name: 'success',
-                type: ABIDataTypes.BOOL,
-            },
-        ],
+        outputs: [],
     },
     {
         name: 'setBonusMultiplier',
@@ -851,12 +771,7 @@ export const MOTOCHEF_ABI: BitcoinInterfaceAbi = [
                 type: ABIDataTypes.UINT256,
             },
         ],
-        outputs: [
-            {
-                name: 'success',
-                type: ABIDataTypes.BOOL,
-            },
-        ],
+        outputs: [],
     },
     {
         name: 'setDev',
@@ -867,12 +782,7 @@ export const MOTOCHEF_ABI: BitcoinInterfaceAbi = [
                 type: ABIDataTypes.ADDRESS,
             },
         ],
-        outputs: [
-            {
-                name: 'success',
-                type: ABIDataTypes.BOOL,
-            },
-        ],
+        outputs: [],
     },
 
     // Ownable

--- a/src/abi/shared/json/motoswap/MOTOSWAP_FACTORY_ABI.ts
+++ b/src/abi/shared/json/motoswap/MOTOSWAP_FACTORY_ABI.ts
@@ -73,12 +73,7 @@ export const MotoSwapFactoryAbi: BitcoinInterfaceAbi = [
                 type: ABIDataTypes.ADDRESS,
             },
         ],
-        outputs: [
-            {
-                name: 'success',
-                type: ABIDataTypes.BOOL,
-            },
-        ],
+        outputs: [],
         type: BitcoinAbiTypes.Function,
     },
     {

--- a/src/abi/shared/json/motoswap/MOTOSWAP_POOL_ABI.ts
+++ b/src/abi/shared/json/motoswap/MOTOSWAP_POOL_ABI.ts
@@ -5,7 +5,26 @@ import { OP_20_ABI } from '../opnet/OP_20_ABI.js';
 
 export const MotoSwapPoolEvents: BitcoinInterfaceAbi = [
     {
-        name: 'PoolBurn',
+        name: 'Burned',
+        values: [
+            {
+                name: 'sender',
+                type: ABIDataTypes.ADDRESS,
+            },
+            {
+                name: 'amount0',
+                type: ABIDataTypes.UINT256,
+            },
+            {
+                name: 'amount1',
+                type: ABIDataTypes.UINT256,
+            },
+            { name: 'to', type: ABIDataTypes.ADDRESS },
+        ],
+        type: BitcoinAbiTypes.Event,
+    },
+    {
+        name: 'Minted',
         values: [
             {
                 name: 'sender',
@@ -23,25 +42,7 @@ export const MotoSwapPoolEvents: BitcoinInterfaceAbi = [
         type: BitcoinAbiTypes.Event,
     },
     {
-        name: 'PoolMint',
-        values: [
-            {
-                name: 'sender',
-                type: ABIDataTypes.ADDRESS,
-            },
-            {
-                name: 'amount0',
-                type: ABIDataTypes.UINT256,
-            },
-            {
-                name: 'amount1',
-                type: ABIDataTypes.UINT256,
-            },
-        ],
-        type: BitcoinAbiTypes.Event,
-    },
-    {
-        name: 'Swap',
+        name: 'Swapped',
         values: [
             {
                 name: 'sender',
@@ -71,7 +72,7 @@ export const MotoSwapPoolEvents: BitcoinInterfaceAbi = [
         type: BitcoinAbiTypes.Event,
     },
     {
-        name: 'Sync',
+        name: 'Synced',
         values: [
             {
                 name: 'reserve0',
@@ -99,12 +100,7 @@ export const MotoswapPoolAbi: BitcoinInterfaceAbi = [
                 type: ABIDataTypes.ADDRESS,
             },
         ],
-        outputs: [
-            {
-                name: 'success',
-                type: ABIDataTypes.BOOL,
-            },
-        ],
+        outputs: [],
         type: BitcoinAbiTypes.Function,
     },
 
@@ -128,24 +124,14 @@ export const MotoswapPoolAbi: BitcoinInterfaceAbi = [
                 type: ABIDataTypes.BYTES,
             },
         ],
-        outputs: [
-            {
-                name: 'success',
-                type: ABIDataTypes.BOOL,
-            },
-        ],
+        outputs: [],
         type: BitcoinAbiTypes.Function,
     },
 
     {
         name: 'skim',
         inputs: [],
-        outputs: [
-            {
-                name: 'success',
-                type: ABIDataTypes.BOOL,
-            },
-        ],
+        outputs: [],
         type: BitcoinAbiTypes.Function,
     },
 
@@ -243,12 +229,7 @@ export const MotoswapPoolAbi: BitcoinInterfaceAbi = [
     {
         name: 'sync',
         inputs: [],
-        outputs: [
-            {
-                name: 'success',
-                type: ABIDataTypes.BOOL,
-            },
-        ],
+        outputs: [],
         type: BitcoinAbiTypes.Function,
     },
     {

--- a/src/abi/shared/json/motoswap/MOTOSWAP_ROUTER_ABI.ts
+++ b/src/abi/shared/json/motoswap/MOTOSWAP_ROUTER_ABI.ts
@@ -245,12 +245,7 @@ export const MOTOSWAP_ROUTER_ABI: BitcoinInterfaceAbi = [
                 type: ABIDataTypes.UINT64,
             },
         ],
-        outputs: [
-            {
-                name: 'success',
-                type: ABIDataTypes.BOOL,
-            },
-        ],
+        outputs: [],
         type: BitcoinAbiTypes.Function,
     },
 

--- a/src/abi/shared/json/motoswap/MOTOSWAP_STAKING_ABI.ts
+++ b/src/abi/shared/json/motoswap/MOTOSWAP_STAKING_ABI.ts
@@ -28,12 +28,7 @@ const MOTOSWAP_OWNABLE_REENTRANCY_GUARD_ABI: BitcoinInterfaceAbi = [
                 type: ABIDataTypes.ADDRESS,
             },
         ],
-        outputs: [
-            {
-                name: 'success',
-                type: ABIDataTypes.BOOL,
-            },
-        ],
+        outputs: [],
     },
 
     // Reentrancy guard
@@ -156,7 +151,7 @@ export const MOTOSWAP_STAKING_ABI: BitcoinInterfaceAbi = [
         constant: false,
         payable: false,
         inputs: [{ name: 'amount', type: ABIDataTypes.UINT256 }],
-        outputs: [{ name: 'success', type: ABIDataTypes.BOOL }],
+        outputs: [],
     },
     {
         name: 'unstake',
@@ -164,7 +159,7 @@ export const MOTOSWAP_STAKING_ABI: BitcoinInterfaceAbi = [
         constant: false,
         payable: false,
         inputs: [],
-        outputs: [{ name: 'success', type: ABIDataTypes.BOOL }],
+        outputs: [],
     },
     {
         name: 'claimRewards',
@@ -172,7 +167,7 @@ export const MOTOSWAP_STAKING_ABI: BitcoinInterfaceAbi = [
         constant: false,
         payable: false,
         inputs: [],
-        outputs: [{ name: 'success', type: ABIDataTypes.BOOL }],
+        outputs: [],
     },
     {
         name: 'adminAddRewardToken',
@@ -180,7 +175,7 @@ export const MOTOSWAP_STAKING_ABI: BitcoinInterfaceAbi = [
         constant: false,
         payable: false,
         inputs: [{ name: 'token', type: ABIDataTypes.ADDRESS }],
-        outputs: [{ name: 'success', type: ABIDataTypes.BOOL }],
+        outputs: [],
     },
     {
         name: 'adminRemoveRewardToken',
@@ -188,7 +183,7 @@ export const MOTOSWAP_STAKING_ABI: BitcoinInterfaceAbi = [
         constant: false,
         payable: false,
         inputs: [{ name: 'token', type: ABIDataTypes.ADDRESS }],
-        outputs: [{ name: 'success', type: ABIDataTypes.BOOL }],
+        outputs: [],
     },
     {
         name: 'adminChangeMotoAddress',
@@ -196,7 +191,7 @@ export const MOTOSWAP_STAKING_ABI: BitcoinInterfaceAbi = [
         constant: false,
         payable: false,
         inputs: [{ name: 'token', type: ABIDataTypes.ADDRESS }],
-        outputs: [{ name: 'success', type: ABIDataTypes.BOOL }],
+        outputs: [],
     },
     {
         name: 'adminChangeLockupParameters',
@@ -208,7 +203,7 @@ export const MOTOSWAP_STAKING_ABI: BitcoinInterfaceAbi = [
             { name: 'newMaxSlashingFeePercent', type: ABIDataTypes.UINT256 },
             { name: 'newBlocksPerOnePercentSlashingFeeReduction', type: ABIDataTypes.UINT256 },
         ],
-        outputs: [{ name: 'success', type: ABIDataTypes.BOOL }],
+        outputs: [],
     },
     {
         name: 'adminEnableEmergencyWithdrawals',
@@ -216,7 +211,7 @@ export const MOTOSWAP_STAKING_ABI: BitcoinInterfaceAbi = [
         constant: false,
         payable: false,
         inputs: [],
-        outputs: [{ name: 'success', type: ABIDataTypes.BOOL }],
+        outputs: [],
     },
 
     // Ownable Reentrancy Guard

--- a/src/abi/shared/json/motoswap/MOTO_ABI.ts
+++ b/src/abi/shared/json/motoswap/MOTO_ABI.ts
@@ -18,58 +18,26 @@ export const MOTO_ABI: BitcoinInterfaceAbi = [
     {
         name: 'changeAdmin',
         type: BitcoinAbiTypes.Function,
-        inputs: [
-            {
-                name: 'to',
-                type: ABIDataTypes.ADDRESS,
-            },
-        ],
-        outputs: [
-            {
-                name: 'success',
-                type: ABIDataTypes.BOOL,
-            },
-        ],
+        inputs: [{ name: 'to', type: ABIDataTypes.ADDRESS }],
+        outputs: [],
     },
     {
         name: 'adminMint',
         type: BitcoinAbiTypes.Function,
         inputs: [
-            {
-                name: 'to',
-                type: ABIDataTypes.ADDRESS,
-            },
-            {
-                name: 'amount',
-                type: ABIDataTypes.UINT256,
-            },
+            { name: 'to', type: ABIDataTypes.ADDRESS },
+            { name: 'amount', type: ABIDataTypes.UINT256 },
         ],
-        outputs: [
-            {
-                name: 'success',
-                type: ABIDataTypes.BOOL,
-            },
-        ],
+        outputs: [],
     },
     {
         name: 'adminBurn',
         type: BitcoinAbiTypes.Function,
         inputs: [
-            {
-                name: 'from',
-                type: ABIDataTypes.ADDRESS,
-            },
-            {
-                name: 'amount',
-                type: ABIDataTypes.UINT256,
-            },
+            { name: 'from', type: ABIDataTypes.ADDRESS },
+            { name: 'amount', type: ABIDataTypes.UINT256 },
         ],
-        outputs: [
-            {
-                name: 'success',
-                type: ABIDataTypes.BOOL,
-            },
-        ],
+        outputs: [],
     },
 
     // OP_20

--- a/src/abi/shared/json/opnet/OP_20_ABI.ts
+++ b/src/abi/shared/json/opnet/OP_20_ABI.ts
@@ -8,7 +8,7 @@ import { OP_NET_ABI } from './OP_NET_ABI.js';
  */
 export const OP20Events: BitcoinInterfaceAbi = [
     {
-        name: 'Mint',
+        name: 'Minted',
         values: [
             {
                 name: 'to',
@@ -22,7 +22,7 @@ export const OP20Events: BitcoinInterfaceAbi = [
         type: BitcoinAbiTypes.Event,
     },
     {
-        name: 'Transfer',
+        name: 'Transferred',
         values: [
             {
                 name: 'from',
@@ -40,17 +40,15 @@ export const OP20Events: BitcoinInterfaceAbi = [
         type: BitcoinAbiTypes.Event,
     },
     {
-        name: 'Burn',
+        name: 'Burned',
         values: [
-            {
-                name: 'amount',
-                type: ABIDataTypes.UINT256,
-            },
+            { name: 'from', type: ABIDataTypes.ADDRESS },
+            { name: 'amount', type: ABIDataTypes.UINT256 },
         ],
         type: BitcoinAbiTypes.Event,
     },
     {
-        name: 'Approve',
+        name: 'Approved',
         values: [
             {
                 name: 'owner',
@@ -94,47 +92,45 @@ export const OP_20_ABI: BitcoinInterfaceAbi = [
         type: BitcoinAbiTypes.Function,
     },
     {
-        name: 'approve',
+        name: 'increaseAllowance',
         inputs: [
-            {
-                name: 'spender',
-                type: ABIDataTypes.ADDRESS,
-            },
-            {
-                name: 'amount',
-                type: ABIDataTypes.UINT256,
-            },
+            { name: 'spender', type: ABIDataTypes.ADDRESS },
+            { name: 'amount', type: ABIDataTypes.UINT256 },
         ],
-        outputs: [
-            {
-                name: 'success',
-                type: ABIDataTypes.BOOL,
-            },
-        ],
+        outputs: [],
         type: BitcoinAbiTypes.Function,
     },
     {
-        name: 'approveFrom',
+        name: 'decreaseAllowance',
         inputs: [
-            {
-                name: 'spender',
-                type: ABIDataTypes.ADDRESS,
-            },
-            {
-                name: 'amount',
-                type: ABIDataTypes.UINT256,
-            },
-            {
-                name: 'signature',
-                type: ABIDataTypes.BYTES,
-            },
+            { name: 'spender', type: ABIDataTypes.ADDRESS },
+            { name: 'amount', type: ABIDataTypes.UINT256 },
         ],
-        outputs: [
-            {
-                name: 'success',
-                type: ABIDataTypes.BOOL,
-            },
+        outputs: [],
+        type: BitcoinAbiTypes.Function,
+    },
+    {
+        name: 'increaseAllowanceBySignature',
+        inputs: [
+            { name: 'owner', type: ABIDataTypes.ADDRESS },
+            { name: 'spender', type: ABIDataTypes.ADDRESS },
+            { name: 'amount', type: ABIDataTypes.UINT256 },
+            { name: 'deadline', type: ABIDataTypes.UINT64 },
+            { name: 'signature', type: ABIDataTypes.BYTES },
         ],
+        outputs: [],
+        type: BitcoinAbiTypes.Function,
+    },
+    {
+        name: 'decreaseAllowanceBySignature',
+        inputs: [
+            { name: 'owner', type: ABIDataTypes.ADDRESS },
+            { name: 'spender', type: ABIDataTypes.ADDRESS },
+            { name: 'amount', type: ABIDataTypes.UINT256 },
+            { name: 'deadline', type: ABIDataTypes.UINT64 },
+            { name: 'signature', type: ABIDataTypes.BYTES },
+        ],
+        outputs: [],
         type: BitcoinAbiTypes.Function,
     },
     {
@@ -155,119 +151,54 @@ export const OP_20_ABI: BitcoinInterfaceAbi = [
     },
     {
         name: 'burn',
-        inputs: [
-            {
-                name: 'value',
-                type: ABIDataTypes.UINT256,
-            },
-        ],
-        outputs: [
-            {
-                name: 'success',
-                type: ABIDataTypes.BOOL,
-            },
-        ],
+        inputs: [{ name: 'value', type: ABIDataTypes.UINT256 }],
+        outputs: [],
         type: BitcoinAbiTypes.Function,
     },
     {
-        name: 'transfer',
+        name: 'safeTransfer',
         inputs: [
-            {
-                name: 'recipient',
-                type: ABIDataTypes.ADDRESS,
-            },
-            {
-                name: 'amount',
-                type: ABIDataTypes.UINT256,
-            },
+            { name: 'to', type: ABIDataTypes.ADDRESS },
+            { name: 'amount', type: ABIDataTypes.UINT256 },
+            { name: 'data', type: ABIDataTypes.BYTES },
         ],
-        outputs: [
-            {
-                name: 'success',
-                type: ABIDataTypes.BOOL,
-            },
-        ],
+        outputs: [],
         type: BitcoinAbiTypes.Function,
     },
     {
-        name: 'transferFrom',
+        name: 'safeTransferFrom',
         inputs: [
-            {
-                name: 'sender',
-                type: ABIDataTypes.ADDRESS,
-            },
-            {
-                name: 'recipient',
-                type: ABIDataTypes.ADDRESS,
-            },
-            {
-                name: 'amount',
-                type: ABIDataTypes.UINT256,
-            },
+            { name: 'from', type: ABIDataTypes.ADDRESS },
+            { name: 'to', type: ABIDataTypes.ADDRESS },
+            { name: 'amount', type: ABIDataTypes.UINT256 },
+            { name: 'data', type: ABIDataTypes.BYTES },
         ],
-        outputs: [
-            {
-                name: 'success',
-                type: ABIDataTypes.BOOL,
-            },
-        ],
+        outputs: [],
         type: BitcoinAbiTypes.Function,
     },
     {
         name: 'mint',
         inputs: [
-            {
-                name: 'recipient',
-                type: ABIDataTypes.ADDRESS,
-            },
-            {
-                name: 'amount',
-                type: ABIDataTypes.UINT256,
-            },
+            { name: 'recipient', type: ABIDataTypes.ADDRESS },
+            { name: 'amount', type: ABIDataTypes.UINT256 },
         ],
-        outputs: [
-            {
-                name: 'success',
-                type: ABIDataTypes.BOOL,
-            },
-        ],
+        outputs: [],
         type: BitcoinAbiTypes.Function,
     },
     {
         name: 'airdrop',
-        inputs: [
-            {
-                name: 'map',
-                type: ABIDataTypes.ADDRESS_UINT256_TUPLE,
-            },
-        ],
-        outputs: [
-            {
-                name: 'success',
-                type: ABIDataTypes.BOOL,
-            },
-        ],
+        inputs: [{ name: 'map', type: ABIDataTypes.ADDRESS_UINT256_TUPLE }],
+        outputs: [],
         type: BitcoinAbiTypes.Function,
     },
 
     {
         name: 'airdropWithAmount',
         inputs: [
-            {
-                name: 'amount',
-                type: ABIDataTypes.UINT256,
-            },
-            {
-                name: 'addresses',
-                type: ABIDataTypes.ARRAY_OF_ADDRESSES,
-            },
+            { name: 'amount', type: ABIDataTypes.UINT256 },
+            { name: 'addresses', type: ABIDataTypes.ARRAY_OF_ADDRESSES },
         ],
-        outputs: [
-            {
-                name: 'success',
-                type: ABIDataTypes.BOOL,
-            },
-        ],
+        outputs: [],
         type: BitcoinAbiTypes.Function,
     },
 
@@ -320,6 +251,29 @@ export const OP_20_ABI: BitcoinInterfaceAbi = [
         outputs: [
             {
                 name: 'maximumSupply',
+                type: ABIDataTypes.UINT256,
+            },
+        ],
+        type: BitcoinAbiTypes.Function,
+    },
+    {
+        name: 'domainSeparator',
+        constant: true,
+        outputs: [
+            {
+                name: 'domainSeparator',
+                type: ABIDataTypes.BYTES32,
+            },
+        ],
+        type: BitcoinAbiTypes.Function,
+    },
+    {
+        name: 'nonceOf',
+        constant: true,
+        inputs: [{ name: 'owner', type: ABIDataTypes.ADDRESS }],
+        outputs: [
+            {
+                name: 'nonce',
                 type: ABIDataTypes.UINT256,
             },
         ],

--- a/src/contracts/Contract.ts
+++ b/src/contracts/Contract.ts
@@ -823,7 +823,7 @@ function contractBase<T extends BaseContractProperties>(): new (
  *    254, 244, 21, 57, 153, 34, 205, 138, 4, 72, 92, 2,
  * ]);
  * const provider: JSONRpcProvider = new JSONRpcProvider('https://regtest.opnet.org');
- * const contract: IOP_20Contract = getContract<IOP_20Contract>(
+ * const contract: IOP20Contract = getContract<IOP20Contract>(
  *     contractAddress,
  *     OP_20_ABI,
  *     provider,

--- a/src/opnet.ts
+++ b/src/opnet.ts
@@ -105,7 +105,7 @@ export * from './abi/shared/interfaces/motoswap/IMotoswapFactoryContract.js';
 export * from './abi/shared/interfaces/motoswap/IMotoswapPoolContract.js';
 export * from './abi/shared/interfaces/motoswap/IMotoswapRouterContract.js';
 export * from './abi/shared/interfaces/motoswap/INativeSwapContract.js';
-export * from './abi/shared/interfaces/opnet/IOP_20Contract.js';
+export * from './abi/shared/interfaces/opnet/IOP20Contract.js';
 export * from './abi/shared/interfaces/opnet/IOP_NETContract.js';
 export * from './abi/shared/interfaces/motoswap/IMotoswapStakingContract.js';
 


### PR DESCRIPTION
## Summary
- rename IOP_20Contract to IOP20Contract
- add `domainSeparator` and `nonceOf` to OP20 interface and ABI
- drop deprecated success returns in MotoChef and staking contracts
- rename MotoChef events to new names
- adjust imports and README for renamed interface

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ddf1e3988832490a41d7ef437eb32