### PR TITLE
feat: accept optional walletProvider on CallResult transactions

### DIFF
--- a/src/contracts/CallResult.ts
+++ b/src/contracts/CallResult.ts
@@ -13,6 +13,7 @@ import {
     RawChallenge,
     SupportedTransactionVersion,
     TransactionFactory,
+    Web3Provider,
 } from '@btc-vision/transaction';
 import { UTXO } from '../bitcoin/UTXOs.js';
 import { BitcoinFees } from '../block/BlockGasParameters.js';
@@ -65,6 +66,17 @@ export interface TransactionParameters {
     readonly challenge?: ChallengeSolution;
 
     readonly subtractExtraUTXOFromAmountRequired?: boolean;
+
+    /**
+     * Optional browser wallet provider to route signing through a specific wallet
+     * (e.g. when multiple OPNet-compatible wallets are installed).
+     * When omitted, TransactionFactory falls back to auto-detecting
+     * `window.opnet.web3` — preserving current behavior.
+     *
+     * Requires @btc-vision/transaction >= 1.8.6 with the `walletProvider` param
+     * on `signInteraction` (see btc-vision/transaction#128).
+     */
+    readonly walletProvider?: Web3Provider;
 }
 
 export interface UTXOTrackingInfo {
@@ -431,7 +443,10 @@ export class CallResult<
                   }
                 : sharedParams;
 
-        const transaction = await factory.signInteraction(params);
+        const transaction = await factory.signInteraction(
+            params,
+            interactionParams.walletProvider,
+        );
 
         const csvUTXOs = UTXOs.filter((u) => u.isCSV === true);
         const p2wdaUTXOs = UTXOs.filter((u) => u.witnessScript && u.isCSV !== true);


### PR DESCRIPTION
## Summary

Adds an optional `walletProvider?: Web3Provider` field to `TransactionParameters`, forwarded to `factory.signInteraction()` inside `CallResult.signTransaction()`. This closes the multi-wallet routing gap for contract interactions invoked via the fluent API (`contract.method(...).sendTransaction(...)`).

Companion to [btc-vision/transaction#128](https://github.com/btc-vision/transaction/pull/128), which adds the matching parameter on `TransactionFactory.signInteraction()`. Same backward-compatible pattern.

## The problem

Per the official docs, contract calls MUST go through `getContract()` → `sim.sendTransaction()` (the `opnet` package), not through `@btc-vision/transaction` directly. However, `CallResult.signTransaction()` currently calls `factory.signInteraction(params)` without forwarding any wallet provider, so every contract interaction routes to `window.opnet.web3` via auto-detect.

When a dApp connects a non-OP_WALLET via `@btc-vision/walletconnect` (e.g. MyScribe), the connect modal shows the wallet correctly, but every subsequent `sim.sendTransaction()` call intercepts through OP_WALLET regardless of which wallet the dApp thinks is connected. No amount of dApp-side code can fix this without the library accepting the pluggable provider.

## Changes

Single file: `src/contracts/CallResult.ts`

- Import `Web3Provider` from `@btc-vision/transaction` (already re-exported from the main entry)
- Add `walletProvider?: Web3Provider` to the `TransactionParameters` interface
- Forward it to `factory.signInteraction(params, interactionParams.walletProvider)`

When omitted, behavior is identical to today (preserves auto-detect).

## Usage

```typescript
import { useWalletConnect } from '@btc-vision/walletconnect';

const { walletInstance } = useWalletConnect();
const web3 = (walletInstance as any)?.web3 as Web3Provider | undefined;
// Cast goes away once walletconnect exposes `web3` typed on the hook
// return — small follow-up PR after #23 lands.

const sim = await contract.transfer(recipient, amount);
const receipt = await sim.sendTransaction({
    signer: null,
    mldsaSigner: null,
    refundTo: walletAddress,
    maximumAllowedSatToSpend: 10000n,
    network: networks.opnetTestnet,
    walletProvider: web3,  // routes to the connected wallet
});
```

## End-to-end verification

The complete fix chain (walletconnect #23 + #25 + transaction #128 + this PR) is deployed at https://testnet.myscribe.org and re-verified on the rebuilt testnet (commit `5f6ae71`, 2026-04-26) with **OP_WALLET and MyScribe installed simultaneously**. Deploy & Claim triggers two on-chain transactions (profile deploy + username register) — both must route to the connected wallet's own extension popup.

**MyScribe connected** (`mswallet_test_1`):
- Deploy: https://opscan.org/transactions/f3f0eba6201320b45688e6fddb0ccd30d1bcf03ae9b3a63696a24adcb30e4628?network=op_testnet
- Register: https://opscan.org/transactions/702bc90a0372d1ca76d7d0792c0d43c8199628bc8f585212261c301f28b016f1?network=op_testnet
- Both signed via the MyScribe extension popup. No OP_WALLET interception.

**OP_WALLET connected** (`opwallet_test_1`, clean reconnect):
- Deploy: https://opscan.org/transactions/86d784c978102610563b966189a1825d5055b73d377cb9d21e842a67590b13be?network=op_testnet
- Register: https://opscan.org/transactions/3a0af55cfd3e21764b59ff26aedcd2954beafecdb6f7e415ef2c39ad58d72fa9?network=op_testnet
- Both signed via the OP_WALLET extension popup. No MyScribe interception.

Symmetry confirmed — no cross-wallet interception in either direction.

## Testing

- `npm run build` passes (ESLint + TypeScript clean)
- `npm test` — 300 existing tests pass. 2 pre-existing failures in `test/utxos-manager.test.ts` reproduce on `main` — unrelated to this change.

## Local-build instructions for reviewers

This PR depends on btc-vision/transaction#128. Until that merges and publishes (as the next `@btc-vision/transaction` release after current `1.8.7-beta.0`), building this PR locally requires a one-time link:

```bash
# 1. Build the transaction fork
git clone https://github.com/MyScribe-Ecosystem/transaction-upstream-pr.git
cd transaction-upstream-pr
git checkout feat/pluggable-wallet-provider
npm install
npm run browserBuild && npm run build
npm pack  # produces btc-vision-transaction-1.8.6.tgz

# 2. Build this PR against the local tarball
cd /path/to/opnet-fork
npm install /path/to/btc-vision-transaction-1.8.6.tgz
npm install
npm run build
npm test
```

Alternatively, once #128 merges and the next `@btc-vision/transaction` release is published, `npm install` resolves cleanly with no manual linking.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

